### PR TITLE
Memory leak and app crash fixes

### DIFF
--- a/Notchy/View Controllers/WelcomeViewController.swift
+++ b/Notchy/View Controllers/WelcomeViewController.swift
@@ -46,15 +46,17 @@ final class WelcomeViewController: UIViewController {
 
     @objc func selectScreenshotButtonDidTouchUpInside(_ sender: Any) {
         PHPhotoLibrary.requestAuthorization { [unowned self] status in
-            switch status {
-            case .notDetermined, .restricted, .denied:
-                let alert = UIAlertController(title: "Photo Library Inaccessible", message: "Notchy couldn't read your photo library.", preferredStyle: .alert)
-                alert.addAction(UIAlertAction(title: "OK", style: .default, handler: nil))
-                self.present(alert, animated: true, completion: nil)
+            DispatchQueue.main.async {
+                switch status {
+                case .notDetermined, .restricted, .denied:
+                    let alert = UIAlertController(title: "Photo Library Inaccessible", message: "Notchy couldn't read your photo library.", preferredStyle: .alert)
+                    alert.addAction(UIAlertAction(title: "OK", style: .default, handler: nil))
+                    self.present(alert, animated: true, completion: nil)
 
-            case .authorized:
-                let navigation = NotchyNavigationController(rootViewController: GridViewController())
-                self.present(navigation, animated: true, completion: nil)
+                case .authorized:
+                    let navigation = NotchyNavigationController(rootViewController: GridViewController())
+                    self.present(navigation, animated: true, completion: nil)
+                }
             }
         }
     }

--- a/Notchy/Views/NotchyToolbar.swift
+++ b/Notchy/Views/NotchyToolbar.swift
@@ -96,7 +96,7 @@ final class CheckmarkView: UIStackView {
 }
 
 final class NotchyToolbar: UIView {
-    @objc private var delegate: NotchyToolbarDelegate!
+    @objc private weak var delegate: NotchyToolbarDelegate?
 
     private var shareButton: PlainButton!
     private var saveButton: ShortPlainButton!


### PR DESCRIPTION
This PR fixes a couple of issues I faced during the project onboarding

- the app crashed when the photo library permissions were accepted since the PHPhotoLibrary callback is issued on a background thread and the app tried to run UI-related tasks from there
- there was quite a large memory leak when the `SingleImageViewController` was being presented and dismissed. The leak was caused by the controller having a strong reference to a toolbar instance, and the toolbar had a strong delegate reference to the view controller thus causing a retain cycle. See the memory comparison before and after the fix below

<img width="1092" alt="Screen Shot 2019-10-08 at 6 28 33 AM" src="https://user-images.githubusercontent.com/1830010/66365510-ea312900-e995-11e9-8d27-9de71909d808.png">
<img width="1111" alt="Screen Shot 2019-10-08 at 6 29 52 AM" src="https://user-images.githubusercontent.com/1830010/66365511-ea312900-e995-11e9-8734-542420dedba0.png">
